### PR TITLE
WebKitGTK+ -> WebKitGTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 webkitgtk.org
 =============
 
-The WebKitGTK+ website.
+The WebKitGTK website.
 
-New version of the WebKitGTK+ website done in [Jekyll](http://jekyllrb.com/)
+New version of the WebKitGTK website done in [Jekyll](http://jekyllrb.com/)
 using the style of GNOME project pages.
 
 In order to test it you need to install Jeykyll, you can do it with the

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,8 @@
     <title>{% if page.title %} {{ page.title }} - {% endif %}{{ site.name }}</title>
     <link rel="stylesheet" type="text/css" media="all" href="/style.css">
 
-    <link rel="alternate" type="application/rss+xml" title="Subscribe to WebKitGTK+ news (RSS feed)" href="/rss.xml" />
-    <link rel="alternate" type="application/atom+xml" title="Subscribe to WebKitGTK+ news (Atom feed)" href="/atom.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Subscribe to WebKitGTK news (RSS feed)" href="/rss.xml" />
+    <link rel="alternate" type="application/atom+xml" title="Subscribe to WebKitGTK news (Atom feed)" href="/atom.xml" />
 
 </head>
 
@@ -29,7 +29,7 @@
 
         <div id="title_bar">
             <div class="maxwidth">
-                <span id="site_title"><a href="/">WebKitGTK+</a></span>
+                <span id="site_title"><a href="/">WebKitGTK</a></span>
             </div>
         </div>
 
@@ -56,10 +56,10 @@
                         <div class="header download"><span>Releases</span></div>
                         <ul>
                             <li><span class="subheader">&#8227; Stable tarball</span>
-                                <p><a href="/releases/webkitgtk-{{ site.stable-release-version}}.tar.xz">WebKitGTK+ {{ site.stable-release-version }}</a></p>
+                                <p><a href="/releases/webkitgtk-{{ site.stable-release-version}}.tar.xz">WebKitGTK {{ site.stable-release-version }}</a></p>
                             </li>
                             <li><span class="subheader">&#8227; Unstable tarball</span>
-                                <p><a href="/releases/webkitgtk-{{ site.unstable-release-version }}.tar.xz">WebKitGTK+ {{ site.unstable-release-version }}</a></p>
+                                <p><a href="/releases/webkitgtk-{{ site.unstable-release-version }}.tar.xz">WebKitGTK {{ site.unstable-release-version }}</a></p>
                             </li>
                             <li><span class="subheader">(<a href="/releases/">more</a>)</span>
                         </ul>
@@ -92,7 +92,7 @@
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-help">webkit-help</a></p>
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-dev">webkit-dev</a></p>
                             </li>
-                            <li><span class="subheader">&#8227; #webkitgtk+ on freenode</span></li>
+                            <li><span class="subheader">&#8227; #webkitgtk on freenode</span></li>
                             <li><span class="subheader">&#8227; <a href="http://www.twitter.com/webkitgtk">@WebKitGTK on Twitter</a></span></li>
                         </ul>
                     </div>
@@ -116,7 +116,7 @@
 
     <div id="footer">
         <div class="maxwidth">
-            <span class="left">Copyright © 2009‒2019 The WebKitGTK+ Team</span>
+            <span class="left">Copyright © 2009‒2019 The WebKitGTK Team</span>
             <span class="right">Hosting kindly provided by <a href="https://www.igalia.com/">Igalia</a>.</span>
             <div class="clear"></div>
         </div>

--- a/generate-security-advisory
+++ b/generate-security-advisory
@@ -48,7 +48,7 @@ Cc: security@webkit.org, distributor-list@gnome.org, oss-security@lists.openwall
 
 Date reported           : %(reportdate)s
 Advisory ID             : %(WSA)s
-WebKitGTK+ Advisory URL : https://webkitgtk.org/security/%(WSA)s.html
+WebKitGTK Advisory URL  : https://webkitgtk.org/security/%(WSA)s.html
 WPE WebKit Advisory URL : https://wpewebkit.org/security/%(WSA)s.html
 CVE identifiers         : %(cvelist)s
 
@@ -202,7 +202,7 @@ def generate_advisory(cve_info,mail=True):
     advisorytext = ""
     WSA=_getWSAid(postsdir)
     reportdate=time.strftime("%B %d, %Y")
-    title = "WebKitGTK+ and WPE WebKit Security Advisory"
+    title = "WebKitGTK and WPE WebKit Security Advisory"
     titlespaces=" "*(72-len(title)-len(WSA) if mail else 1)
     ident=" "*4
 
@@ -218,7 +218,7 @@ def generate_advisory(cve_info,mail=True):
         cves = _cve_mitre_links(cves,anchor=True)
         cves = _beautify_line_for_print(cves, " "*2, width=90)
 
-    affectedtext = ("Several vulnerabilities were discovered in WebKitGTK+ and WPE WebKit.")
+    affectedtext = ("Several vulnerabilities were discovered in WebKitGTK and WPE WebKit.")
     affectedtext = _beautify_line_for_print(affectedtext, "")
 
     advisorytext += (headertemplate %{ 'reportdate':reportdate,
@@ -245,14 +245,14 @@ def generate_advisory(cve_info,mail=True):
                               'description':description.strip()
                               })
     # Generate text for Footer
-    fixedvers =  "We recommend updating to the latest stable versions of WebKitGTK+ and WPE WebKit. "
+    fixedvers =  "We recommend updating to the latest stable versions of WebKitGTK and WPE WebKit. "
     fixedvers += "It is the best way to ensure that you are running safe versions of WebKit. "
     fixedvers += "Please check our websites for information about the latest stable releases."
     fixedvers = _beautify_line_for_print(fixedvers,"", dot=False)
-    moreinfo="Further information about WebKitGTK+ and WPE WebKit security advisories can be found at: "
+    moreinfo="Further information about WebKitGTK and WPE WebKit security advisories can be found at: "
     if mail:
         moreinfo = _beautify_line_for_print(moreinfo + "https://webkitgtk.org/security.html or https://wpewebkit.org/security/", "")
-        signature = "The WebKitGTK+ and WPE WebKit team," + "\n" + reportdate
+        signature = "The WebKitGTK and WPE WebKit team," + "\n" + reportdate
     else:
         moreinfo = moreinfo + "\n" + "[https://webkitgtk.org/security.html](https://webkitgtk.org/security.html) or [https://wpewebkit.org/security/](https://wpewebkit.org/security/)."
         signature = ""

--- a/index.md
+++ b/index.md
@@ -2,16 +2,16 @@
 layout: default
 ---
 
-![Screenshot of Epiphany using WebKitGTK+](/images/screenshot.png)
+![Screenshot of Epiphany using WebKitGTK](/images/screenshot.png)
 
 ## Web content rendering ##
 
-WebKitGTK+ is a full-featured port of the WebKit rendering engine,
+WebKitGTK is a full-featured port of the WebKit rendering engine,
 suitable for projects requiring any kind of web integration, from hybrid
 HTML/CSS applications to full-fledged web browsers. It offers WebKit's
 full functionality and is useful in a wide range of systems from desktop
 computers to embedded systems like phones, tablets, and televisions.
-WebKitGTK+ is made by a lively community of developers and designers,
+WebKitGTK is made by a lively community of developers and designers,
 who hope to bring the web platform to everyone.
 It's the official web engine of the GNOME platform and is used in
 browsers such as [Epiphany](http://projects.gnome.org/epiphany/) and
@@ -22,8 +22,8 @@ browsers such as [Epiphany](http://projects.gnome.org/epiphany/) and
 Since adding support for WebKit2, it's possible to build applications that
 use the web platform with increased security and responsiveness. The web
 is a jungle, but web pages cannot crash the main application or freeze the
-UI. WebKitGTK+ also uses process separation to seamlessly support GTK+2 plugins
-(like Flash) in GTK+3 applications.
+UI. WebKitGTK also uses process separation to seamlessly support GTK 2 plugins
+(like Flash) in GTK 3 applications.
 
 ## Accessibility ##
 
@@ -40,7 +40,7 @@ support for WebAudio and WebRTC.
 
 ## 3D CSS and accelerated rendering ##
 
-WebKitGTK+ can use the GPU to enable smooth page compositing and
+WebKitGTK can use the GPU to enable smooth page compositing and
 scrolling, as well as 3D CSS transforms and 3D HTML canvas (otherwise
-known as WebGL). This makes WebKitGTK+ suitable for a whole range
+known as WebGL). This makes WebKitGTK suitable for a whole range
 of games and visualization applications.

--- a/planet/webkitgtk.ini
+++ b/planet/webkitgtk.ini
@@ -9,9 +9,9 @@
 
 [Planet]
 
-name            = Planet WebKitGTK+
+name            = Planet WebKitGTK
 link            = https://planet.webkitgtk.org/
-owner_name      = WebKitGTK+ Team
+owner_name      = WebKitGTK Team
 owner_email     = planet@webkitgtk.org
 output_theme    = .
 cache_directory = ../_cache


### PR DESCRIPTION
Note this assumes we rename the IRC room from #webkitgtk+ to #webkitgtk,
paralleling the #gtk+ -> #gtk IRC room change.

We also still need to update the gtkdoc.

CC: @aperezdc @carlosgcampos 