### PR TITLE
Replace Midori mention with Eolie

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ WebKitGTK is made by a lively community of developers and designers,
 who hope to bring the web platform to everyone.
 It's the official web engine of the GNOME platform and is used in
 browsers such as [Epiphany](http://projects.gnome.org/epiphany/) and
-[Midori](http://twotoasts.de/index.php/midori/).
+[Eolie](https://wiki.gnome.org/Apps/Eolie).
 
 ## Web process separation ##
 


### PR DESCRIPTION
Midori does not use WebKitGTK anymore, it is now Electron as per [its FAQ](https://gitlab.com/midori-web/midori-desktop/-/blob/master/README.md#faq). OTOH, [Eolie](https://wiki.gnome.org/Apps/Eolie) is a full-featured browser which better showcases what can be done with WebKitGTK because it's UI/UX is rather different from Midori and Epiphany^W GNOME Web, so it should deserve a mention.