### PR TITLE
Remove references to freenode

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,7 +92,8 @@
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-help">webkit-help</a></p>
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-dev">webkit-dev</a></p>
                             </li>
-                            <li><span class="subheader">&#8227; #webkitgtk on freenode</span></li>
+                            <li><span class="subheader">&#8227; #webkitgtk on irc.gnome.org</span></li>
+                            <li><span class="subheader">&#8227; <a href="https://matrix.to/#/%23webkitgtk:matrix.org">#webkitgtk:matrix.org</a></span></li>
                             <li><span class="subheader">&#8227; <a href="http://www.twitter.com/webkitgtk">@WebKitGTK on Twitter</a></span></li>
                         </ul>
                     </div>

--- a/webkit-release
+++ b/webkit-release
@@ -407,7 +407,8 @@ you may:
   typically prefixed by "[GTK]." A bug report with a minimal,
   reproducible test case is often just as valuable as a patch.
 
-- Join the #webkit and #webkitgtk IRC channels at irc.freenode.net.
+- Join the #webkitgtk IRC channel at irc.gnome.org or on Matrix at
+  #webkitgtk:matrix.org.
 
 - Subscribe to the WebKitGTK mailing list,
   https://lists.webkit.org/mailman/listinfo/webkit-gtk, or the


### PR DESCRIPTION
webkitgtk's IRC channel has moved to GIMPNet.

The #webkit channel moved to Slack, but no need to encourage that in our
release announcements IMO.