### PR TITLE
Remove link to IRC room

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -116,7 +116,6 @@
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-help">webkit-help</a></p>
                                 <p><a href="http://lists.webkit.org/mailman/listinfo/webkit-dev">webkit-dev</a></p>
                             </li>
-                            <li><span class="subheader">&#8227; #webkitgtk on irc.gnome.org</span></li>
                             <li><span class="subheader">&#8227; <a href="https://matrix.to/#/%23webkitgtk:matrix.org">#webkitgtk:matrix.org</a></span></li>
                             <li><span class="subheader">&#8227; <a rel="me" href="https://floss.social/@WebKitGTK">@WebKitGTK on Mastodon</a></span></li>
                             <li><span class="subheader">&#8227; <a href="http://www.twitter.com/webkitgtk">@WebKitGTK on Twitter</a></span></li>

--- a/webkit-release
+++ b/webkit-release
@@ -371,8 +371,7 @@ you may:
   WebKitGTK bugs are typically prefixed by "[GTK]." A bug report with
   a minimal, reproducible test case is often just as valuable as a patch.
 
-- Join the #webkitgtk IRC channel at irc.gnome.org or on Matrix at
-  #webkitgtk:matrix.org.
+- Join the #webkitgtk:matrix.org Matrix channel.
 
 - Subscribe to the WebKitGTK mailing list,
   https://lists.webkit.org/mailman/listinfo/webkit-gtk or the


### PR DESCRIPTION
Since irc.gnome.org became a link to libera.chat, this room is no longer bridged to Matrix and there are almost no users present there. Let's not advertise it anymore.