### PR TITLE
Make documentation links point to the newest API reference

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,17 +93,18 @@
                         <div class="header documentation"><span>Documentation</span></div>
                         <ul>
                             <li><span class="subheader">&#8227; Stable API Reference</span>
-                                <p><a href="https://webkitgtk.org/reference/webkit2gtk/stable/index.html">WebKit2</a></p>
-                                <p><a href="https://webkitgtk.org/reference/webkit2gtk-web-extension/stable/index.html">WebKit2WebExtension</a></p>
-                                <p><a href="https://webkitgtk.org/reference/jsc-glib/stable/index.html">JavaScriptCore</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkitgtk/stable/">WebKit</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkitgtk-web-process-extension/stable/">WebKit</a></p>
+                                <p><a href="https://webkitgtk.org/reference/jsc-glib/stable/">JavaScriptCore</a></p>
                             </li>
                             <li><span class="subheader">&#8227; Unstable API Reference</span>
-                                <p><a href="https://webkitgtk.org/reference/webkitgtk/unstable/index.html">WebKit</a></p>
-                                <p><a href="https://webkitgtk.org/reference/webkitgtk-web-process-extension/unstable/index.html">WebKitWebProcessExtension</a></p>
-                                <p><a href="https://webkitgtk.org/reference/jsc-glib/unstable/index.html">JavaScriptCore</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkitgtk/unstable/">WebKit</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkitgtk-web-process-extension/unstable/">WebKitWebProcessExtension</a></p>
+                                <p><a href="https://webkitgtk.org/reference/jsc-glib/unstable/">JavaScriptCore</a></p>
                             </li>
                             <li><span class="subheader">&#8227; Deprecated API Reference</span>
-                                <p><a href="https://webkitgtk.org/reference/webkitgtk/stable/index.html" rel="nofollow">WebKit1</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkit2gtk/stable/">WebKit2</a></p>
+                                <p><a href="https://webkitgtk.org/reference/webkit2gtk/1.10.1/">WebKit1</a></p>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
While at it, correct the link for the 1.x API to point to the newest version still using WebKit1/WebKitLegacy, and make a WebKit2 link that points to latest 4.x API reference.