### PR TITLE
wsa: Fetch CVE data lazily using the JSON format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _cache/
 _planet/
 *.tmplc
 
+# Python
+/__pycache__/
+
 # Security advisories temp files
-cvedata/mail.txt
-cvedata/allitems.csv.gz
+/cvedata/cache/

--- a/cve.py
+++ b/cve.py
@@ -1,0 +1,228 @@
+#! /usr/bin/env python3
+
+from dataclasses import dataclass
+from datetime import datetime, UTC
+from functools import cached_property, lru_cache
+from json import load as json_load
+from pathlib import Path
+from time import gmtime
+from typing import Self
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+cve_id_re = re.compile(r"^CVE-(\d+)-(\d+)$")
+
+
+def is_valid_id(cve_id: str) -> bool:
+    """Checks whether a string is a valid CVE identifier."""
+    return cve_id_re.match(cve_id) is not None
+
+
+def parse_id(cve_id: str) -> tuple[int, int]:
+    """Parses a CVE identifier string into its components.
+
+    Returns a tuple with the year and serial numbers extracted from the string.
+    """
+    id_parts_match = cve_id_re.match(cve_id)
+    if id_parts_match is None:
+        raise ValueError(f"Invalid CVE string: {cve_id!r}")
+    return (int(id_parts_match[1]), int(id_parts_match[2]))
+
+
+def unparse_id(cve_id: tuple[int, int]) -> str:
+    """Formats a year in serial number into a CVE identifier."""
+    return f"CVE-{cve_id[0]:04}-{cve_id[1]:04}"
+
+
+@dataclass(frozen=True, slots=True)
+class Id:
+    """Represents a CVE identifier."""
+
+    year: int
+    serial: int
+
+    is_valid = is_valid_id
+
+    @classmethod
+    def parse(cls, cve_id: str) -> Self:
+        """Parses a CVE identifier string into an identifier."""
+        parsed = parse_id(cve_id)
+        return cls(year=parsed[0], serial=parsed[1])
+
+    def __str__(self):
+        """Represents a CVE identifier as a string."""
+        return unparse_id((self.year, self.serial))
+
+
+class Entry:
+    """Convenience class to access CVE JSON data."""
+
+    _data: dict
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    @cached_property
+    def identifier(self) -> Id:
+        """Identifier for the CVE entry."""
+        return Id.parse(self._data["cveMetadata"]["cveId"])
+
+    @cached_property
+    def published(self):
+        """Whether the CVE entry has been published."""
+        return self._data["cveMetadata"]["state"] == "PUBLISHED"
+
+    @cached_property
+    def description(self) -> None | str:
+        """CVE entry description."""
+        for container_id, container in self._data.get("containers", {}).items():
+            for desc in container.get("descriptions", ()):
+                if isinstance(desc, dict) and desc.get("lang", None) in ("en", "eng"):
+                    return desc["value"]
+        return None
+
+
+def path_datetime(p: Path) -> datetime:
+    mtime = p.stat().st_mtime
+    ms = 1000 * (mtime - int(mtime))
+    t = gmtime(mtime)
+    return datetime(
+        t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, int(ms), UTC
+    )
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    time: datetime
+    data: Entry | None = None
+
+
+class DiskCache:
+    __path: Path
+
+    def __init__(self, path: Path):
+        self.__path = path.absolute()
+        if self.__path.exists():
+            assert self.__path.is_dir()
+        else:
+            self.__path.mkdir(parents=True, exist_ok=True)
+        self._data = None
+
+    def get_json_path(self, cve_id: Id) -> Path:
+        return self.__path / str(cve_id.year) / f"{cve_id!s}.json"
+
+    def get(self, cve_id: Id | str) -> None | Entry:
+        if isinstance(cve_id, str):
+            cve_id = Id.parse(cve_id)
+        assert isinstance(cve_id, Id)
+        entry = self.get_entry(cve_id)
+        return None if entry is None else entry.data
+
+    def get_entry(self, cve_id: Id) -> None | CacheEntry:
+        json_path = self.get_json_path(cve_id)
+        if json_path.is_file() or self.materialize_file(cve_id, json_path):
+            with json_path.open() as fp:
+                json_data = json_load(fp)
+            if json_data.get("dataType", None) != "CVE_RECORD":
+                return None
+            if json_data.get("dataVersion", None) != "5.1":
+                return None
+            return CacheEntry(data=Entry(json_data), time=path_datetime(json_path))
+        return None
+
+    def materialize_file(self, cve_id: Id, json_path: Path) -> bool:
+        return False
+
+
+class DiskFetcherCache(DiskCache):
+    __base_url: str = "https://cveawg.mitre.org/api/cve/{cve_id}"
+
+    def __init__(self, path: Path, base_url: str = None):
+        super().__init__(path)
+        if base_url is not None:
+            self.__base_url = base_url
+
+    def materialize_file(self, cve_id: Id, json_path: Path) -> bool:
+        from urllib.error import HTTPError
+        from urllib.request import urlopen
+
+        json_url = self.__base_url.format(cve_id=cve_id)
+        log.info("%s, fetching: %s", cve_id, json_url)
+
+        try:
+            response = urlopen(json_url)
+        except HTTPError as err:
+            log.debug("%s, exception: %s", cve_id, err)
+            if err.status == 404:
+                return False
+            else:
+                raise
+
+        content_encoding = response.getheader("content-encoding")
+        if content_encoding:
+            content_encoding = content_encoding.lower()
+            log.debug("%s, content encoding: %s", cve_id, content_encoding)
+            if content_encoding in ("gzip", "x-gzip"):
+                from gzip import GzipFile
+
+                response = GzipFile(fileobj=response)
+
+        temp_path = json_path.with_suffix(".fetch")
+        temp_dir = temp_path.parent
+        try:
+            temp_dir.mkdir(exist_ok=True)
+        except Exception as e:
+            log.error("%s, cannot mkdir '%s': %s", cve_id, temp_dir, e)
+            raise
+
+        try:
+            with temp_path.open("wb") as fp:
+                while data := response.read(1024):
+                    fp.write(data)
+        except Exception as e:
+            log.error("%s, cannot write '%s': %s", cve_id, temp_path, e)
+            raise
+
+        log.debug("%s, saved: %s", cve_id, json_path)
+        temp_path.rename(json_path)
+        return True
+
+
+class LRUMemDiskFetcherCache(DiskFetcherCache):
+    @lru_cache
+    def get_entry(self, cve_id: Id) -> None | CacheEntry:
+        return super().get_entry(cve_id)
+
+    def cache_info(self):
+        return self.get_entry.cache_info()
+
+    def cache_clear(self):
+        self.get_entry.cache_clear()
+
+
+__all__ = [
+    "is_valid_id",
+    "parse_id",
+    "unparse_id",
+    "Id",
+    "Entry",
+    "CacheEntry",
+    "DiskCache",
+    "DiskFetcherCache",
+    "LRUMemDiskFetcherCache",
+]
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.DEBUG)
+    cve_id = Id.parse(sys.argv[1])
+    cc = LRUMemDiskFetcherCache(Path(__file__).parent / "cve")
+    cve = cc.get(cve_id)
+    if cve:
+        print(f"{cve.identifier}: {cve.description}")
+    raise SystemExit(1)

--- a/wsa
+++ b/wsa
@@ -65,6 +65,8 @@ class Formatter:
 
     def generate(self, write, cve_data_path: Path|None = None,
                  fill_missing_description=False):
+        cve_cache = None
+
         self.header(write)
 
         for cve_id in sorted(self.wsa_data.keys()):
@@ -93,8 +95,13 @@ class Formatter:
             elif "description" in cve_data:
                 description = cve_data["description"]
             elif fill_missing_description:
-                assert isinstance(cve_data_path, Path)
-                description = get_cve_description(cve_id, pck=cve_data_path)
+                if cve_cache is None:
+                    import cve
+                    assert isinstance(cve_data_path, Path)
+                    cve_cache = cve.LRUMemDiskFetcherCache(cve_data_path)
+                cve = cve_cache.get(cve_id)
+                if cve and cve.description:
+                    description = cve.description
 
             if description is None:
                 description = "No description was provided"
@@ -237,41 +244,9 @@ class Markdown(Formatter):
             text = target
         return f"[{text}]({target})"
 
-_CVE_DESCRIPTION = None
-
-def get_cve_description(cve_id: str, csv: Path|None = None, pck: Path|None = None) -> str | None:
-    global _CVE_DESCRIPTION
-    if _CVE_DESCRIPTION is None:
-        import gzip, pickle
-
-        if pck is None or not pck.is_file():
-            raise SystemExit("Cannot load CVE data dump")
-
-        _CVE_DESCRIPTION = {}
-        if pck.is_file() and (csv is None or (pck.stat().st_mtime >= csv.stat().st_mtime)):
-            with pck.open("rb") as pckf:
-                _CVE_DESCRIPTION = pickle.load(pckf)
-        elif csv is None:
-            raise SystemExit("No CSV file specified")
-        else:
-            with gzip.open(csv, "rt", errors="replace") as gzf:
-                from csv import reader as csvreader
-                reader = csvreader(gzf)
-                for entry in reader:
-                    if not entry[0].startswith("CVE-"):
-                        continue
-                    if entry[1] not in ("Entry", "Candidate"):
-                        continue
-                    _CVE_DESCRIPTION[entry[0]] = entry[2]
-            if pck is not None:
-                with pck.open("wb") as pckf:
-                    pickle.dump(_CVE_DESCRIPTION, pckf)
-
-    return _CVE_DESCRIPTION.get(cve_id, None)
-
 def get_cve_data_path(p: Path | None) -> Path:
     if p is None:
-        p = Path(__file__).parent / "cvedata" / "cvedata.pickle"
+        p = Path(__file__).parent / "cvedata" / "cache"
     return p.resolve()
 
 wsa_id_re = re.compile(r"(WSA-\d{4}-\d+)")
@@ -306,13 +281,14 @@ def cmd_generate(args):
     Fmt(args.wsa_id, wsa_data).generate(sys.stdout.write if args.output is None
                                         else args.output.open("w").write,
                                         cve_data_path=get_cve_data_path(args.cve_data),
-                                        fill_missing_description=(args.cve_data is not None))
+                                        fill_missing_description=args.fill)
 
 def cmd_fill(args):
     if len(args.report_yml) > 1 and not args.inplace:
         raise SystemExit("Option --inplace needs to be used with multiple inputs")
 
-    cve_data_path = get_cve_data_path(args.cve_data)
+    import cve
+    cve_cache = cve.LRUMemDiskFetcherCache(get_cve_data_path(args.cve_data))
 
     yaml = YAML()
     yaml.indent(mapping=2, sequence=4, offset=2)
@@ -323,10 +299,12 @@ def cmd_fill(args):
 
         modified = False
         for cve_id, cve_data in wsa_data.items():
+            if cve_data is None:
+                wsa_data[cve_id] = cve_data = {}
             if "description" not in cve_data:
-                desc = get_cve_description(cve_id, pck=cve_data_path)
-                if desc is not None:
-                    cve_data["description"] = desc
+                cve = cve_cache.get(cve_id)
+                if cve and cve.description:
+                    cve_data["description"] = cve.description
                     modified = True
 
         if args.inplace:
@@ -336,138 +314,13 @@ def cmd_fill(args):
         else:
             yaml.dump(wsa_data, sys.stdout)
 
-class TeeStream:
-    def __init__(self, readable, output: Path):
-        self._output = output.open("wb")
-        self._readable = readable
-
-    def read(self, size):
-        data = self._readable.read(size)
-        self._output.write(data)
-        return data
-
-    def close(self):
-        self._output.close()
-
-    def __del__(self):
-        self.close()
-
-class ReportStream:
-    def __init__(self, readable, length):
-        self._readable = readable
-        self._position = 0
-        self._length = length
-
-        from time import clock_gettime, CLOCK_MONOTONIC
-        self._gettime = lambda : clock_gettime(CLOCK_MONOTONIC)
-        self._last_update = 0
-        self._updating = True
-
-    def __should_update(self):
-        result = False
-        now = self._gettime()
-        if (now - self._last_update) >= 0.5:
-            self._last_update = now
-            result = True
-        return self._updating and (result or self.__finished())
-
-    def __finished(self):
-        return self._position >= self._length
-
-    def read(self, size):
-        if self.__should_update():
-            kib = self._position // 1024
-            if self._length:
-                percent = min(self._position / self._length * 100.0, 100.0)
-                bar_length = int(percent / 5)
-                bar = "#" * bar_length + " " * (20 - bar_length)
-                print(f"\x1b[K{percent:6.2f}% [{bar}] {kib} KiB\r", end="", flush=True)
-            else:
-                print(f"\r\x1b[KDownloaded {kib} KiB...", end="", flush=True)
-            if self.__finished():
-                self._updating = False
-                print()
-        self._position += size
-        return self._readable.read(size)
-
-def cmd_cve_data(args):
-    if args.input and args.fetch_url:
-        raise SystemExit("Must use either --input or --fetch-url, but not both at the same time")
-    if args.input and args.keep_csv:
-        raise SystemExit("Option --keep-csv must be used with --fetch-url")
-
-    tty_output = False
-    stdout_fd = sys.stdout.fileno()
-    if stdout_fd:
-        import os
-        tty_output = os.isatty(stdout_fd)
-
-    cve_data_path = get_cve_data_path(args.cve_data)
-
-    if args.input is not None:
-        readable = args.input.open("rb")
-    else:
-        from urllib.request import urlopen
-        fetch_url = urlunparse(args.fetch_url) if args.fetch_url \
-            else "https://cve.mitre.org/data/downloads/allitems.csv.gz"
-        if tty_output:
-            print(f"URL: {fetch_url}")
-
-        response = urlopen(fetch_url)
-        readable = response
-
-        content_type = response.getheader("content-type")
-        content_length = response.getheader("content-length")
-        content_encoding = response.getheader("content-encoding")
-
-        if tty_output:
-            print(f"Content-Type: {content_type}")
-            print(f"Content-Length: {content_length}")
-            print(f"Content-Encoding: {content_encoding}")
-            if content_length:
-                readable = ReportStream(readable, int(content_length))
-
-        if content_encoding:
-            content_encoding = content_encoding.lower()
-            if content_encoding in ("gzip", "x-gzip"):
-                from gzip import GzipFile
-                readable = GzipFile(fileobj=readable)
-
-        if args.keep_csv:
-            readable = TeeStream(readable, args.keep_csv)
-
-    from encodings import utf_8
-    readable = utf_8.StreamReader(readable, errors="replace")
-
-    import csv
-    cvecsv = csv.reader(readable)
-
-    cve_descriptions = {}
-    for entry in cvecsv:
-        if not entry[0].startswith("CVE-"):
-            continue
-        if entry[1] not in ("Entry", "Candidate"):
-            continue
-        cve_descriptions[entry[0]] = entry[2]
-
-    if tty_output:
-        print(f"Processed {len(cve_descriptions)} entries.")
-        if args.keep_csv:
-            print(f"Saved: {args.keep_csv!s}")
-    readable.close()
-
-    import pickle
-    with cve_data_path.open("wb") as pckf:
-        pickle.dump(cve_descriptions, pckf)
-    if tty_output:
-        print(f"Saved: {cve_data_path!s}")
-
 
 arg_parser = ArgumentParser()
 subparsers = arg_parser.add_subparsers(dest="subcommand", required=True)
 
 gen_parser = subparsers.add_parser("generate", aliases=("gen",), description="Generate advisory text.")
 gen_parser.add_argument("-c", "--cve-data", type=Path, default=None, help="path to the CVE data dump")
+gen_parser.add_argument("-f", "--fill", action="store_true", default=False, help="fill missing fields from CVE data")
 gen_parser.add_argument("-w", "--wsa-id", type=str, help="manually specify generated WSA identifier")
 gen_parser.add_argument("-o", "--output", type=Path, default=None, help="output file path, instead of stdout")
 gen_parser.add_argument("-m", "--markdown", action="store_true", default=False, help="generate Markdown")
@@ -479,16 +332,9 @@ fil_parser.add_argument("-c", "--cve-data", type=Path, default=None, help="path 
 fil_parser.add_argument("-i", "--inplace", action="store_true", default=False, help="edit YAML file in-place")
 fil_parser.add_argument("report_yml", type=Path, nargs="+", help="path to the WSA report YAML source")
 
-cve_parser = subparsers.add_parser("cve-data", aliases=("cve",), description="Manipulate CVE data bundle.")
-cve_parser.add_argument("-i", "--input", type=Path, help="file for the CVE CSV data")
-cve_parser.add_argument("-f", "--fetch-url", type=urlparse, help="URL for the CVE CSV data", metavar="URL")
-cve_parser.add_argument("-k", "--keep-csv", type=Path, help="keep CSV data at the given path")
-cve_parser.add_argument("cve_data", type=Path, nargs="?", help="path to the CVE data dump")
-
 args = arg_parser.parse_args()
 
 ({
     "generate": cmd_generate, "gen": cmd_generate,
-    "cve-data": cmd_cve_data, "cve": cmd_cve_data,
     "fill": cmd_fill,
 })[args.subcommand](args)


### PR DESCRIPTION
Instead of fetching data for all ever published CVEs, download the information for each needed CVE lazily, as needed. While at it, switch to the JSON v5 CVE data format, because the CSV dumps previously used do not allow fetching data for individual CVEs. The CSV dumps have been deprecated in March 2023, too:

- https://www.cve.org/Media/News/item/blog/2023/03/29/CVE-Downloads-in-JSON-5-Format

This introduces a new `cve` module with helper classes to fetch (and cache locally) CVE JSON data on demand, and makes the `wsa` script use the new module for the `fill` and `generate` subcommands. As the CVE data fetches now happen on demand, the `wsa cve-data` subcommand used to fetch a CSV dump is no longer needed.