### PR TITLE
wsa: Speed up "check" subcommand with caching and parallel fetches

### DIFF
--- a/httpcache.py
+++ b/httpcache.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+
+from base64 import b32hexencode
+from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime, UTC
+from email.utils import format_datetime, parsedate_to_datetime
+from hashlib import sha256
+from logging import getLogger
+from pathlib import Path
+from ruamel.yaml import YAML
+from tempfile import NamedTemporaryFile
+from typing import Any, Self
+from urllib.error import HTTPError
+from urllib.request import urlopen, Request
+
+
+log = getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    __YAML = YAML(typ="safe")
+
+    __TIME_DEFAULT = datetime(1970, 1, 1, 0, 0, 0, 0, UTC)
+
+    url: str
+    blob: str | None = None
+    etag: str | None = None
+    type: str | None = None
+    size: int | None = None
+    mtime: datetime = __TIME_DEFAULT
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def __get_http_mtime(self) -> str:
+        return format_datetime(self.mtime, usegmt=True)
+
+    def __set_http_mtime(self, value: str | None):
+        if value:
+            self.mtime = parsedate_to_datetime(value)
+        else:
+            self.mtime = self.__TIME_DEFAULT
+
+    http_mtime = property(__get_http_mtime, __set_http_mtime)
+
+    def get_blob_path(self, base_path: Path) -> Path:
+        if not self.blob:
+            meta_path = self.get_meta_path(base_path)
+            if meta_path.is_file():
+                self.__load(meta_path)
+            if not self.blob:
+                raise ValueError("No 'blob' name set")
+        return base_path / f"B:{self.blob}"
+
+    def open_blob(self, base_path: Path, mode="r"):
+        return self.get_blob_path(base_path).open(mode + "b")
+
+    @classmethod
+    def for_url(cls, base_path: Path, url: str) -> Self:
+        entry = cls(url=url)
+        entry.load(base_path)
+        return entry
+
+    @staticmethod
+    def get_url_meta_path(base_path: Path, url: str) -> Path:
+        encoded_url = b32hexencode(url.encode("ascii")).decode("ascii")
+        return base_path / f"M:{encoded_url}"
+
+    def get_meta_path(self, base_path: Path) -> Path:
+        return self.get_url_meta_path(base_path, self.url)
+
+    def load(self, base_path: Path) -> bool:
+        meta_path = self.get_meta_path(base_path)
+        if meta_path.is_file():
+            self.__load(meta_path)
+            return True
+        return False
+
+    def save(self, base_path: Path):
+        self.__save(self.get_meta_path(base_path))
+
+    def __load(self, meta_path: Path):
+        with meta_path.open("r") as f:
+            data = self.__YAML.load(f)
+        if data["url"] != self.url:
+            raise RuntimeError(f"Inconsitent URL in cache entry:\n "
+                f"- Expected: {self.url}\n - Found: {data["url"]}")
+        for f in fields(self):
+            if f.name == "url":
+                continue
+            if f.name in data:
+                setattr(self, f.name, data[f.name])
+
+    def __save(self, meta_path: Path):
+        with meta_path.open("w") as f:
+            self.__YAML.dump(asdict(self), f)
+
+
+@dataclass(slots=True)
+class Stats:
+    hits: int = 0
+    misses: int = 0
+    errors: int = 0
+
+    bytes_remote: int = 0
+    bytes_local: int = 0
+
+    @property
+    def all(self):
+        return self.hits + self.misses + self.errors
+
+
+class HTTPCache:
+    __path: Path
+    stats: Stats
+
+    def __init__(self, path: Path) -> None:
+        self.__path = path.absolute()
+        if self.__path.exists():
+            assert self.__path.is_dir()
+        else:
+            self.__path.mkdir(parents=True, exist_ok=True)
+        self.stats = Stats()
+
+    def read_blob(self, entry: CacheEntry) -> bytes:
+        return entry.get_blob_path(self.__path).read_bytes()
+
+    def get(self, url: str) -> tuple[CacheEntry, bool]:
+        entry = CacheEntry.for_url(self.__path, url)
+        return (entry, self.__fetch(entry))
+
+    def __fetch(self, entry: CacheEntry) -> bool:
+        log.debug("fetch: %s", entry.url)
+        request = Request(entry.url)
+
+        blob_path = None
+        if entry.blob:
+            blob_path = entry.get_blob_path(self.__path)
+            if blob_path.is_file():
+                if entry.mtime is not None:
+                    log.debug("fetch:  - Last-Modified-Since: %s", entry.http_mtime)
+                    request.add_header("If-Modified-Since", entry.http_mtime)
+                if entry.etag is not None:
+                    log.debug("fetch:  - If-None-Match: %s", entry.etag)
+                    request.add_header("If-None-Match", entry.etag)
+
+        try:
+            response = urlopen(request)
+        except HTTPError as e:
+            if e.status == 304:  # Not Modified
+                log.debug("fetch: ** Cache hit: 304 - Not Modified")
+                if entry.size:
+                    self.stats.bytes_local += entry.size
+                self.stats.hits += 1
+                return True
+            self.stats.errors += 1
+            raise
+
+        log.debug("fetch: ** Cache miss: %d" % response.status)
+
+        entry.http_mtime = response.headers.get("Last-Modified")
+        entry.size = int(response.headers.get("Content-Length", 0))
+        entry.type = response.headers.get("Content-Type")
+        entry.etag = response.headers.get("ETag")
+        log.debug("fetch:  - Last-Modified: %s", entry.http_mtime)
+        log.debug("fetch:  - Content-Length: %r", entry.size)
+        log.debug("fetch:  - Content-Type: %s", entry.type or "")
+        log.debug("fetch:  - ETag: %s", entry.etag or "")
+
+        dl_blob = sha256()
+        dl_file = NamedTemporaryFile("wb+", prefix="T:", dir=self.__path)
+        dl_size = 0
+        while data := response.read(1024):
+            dl_size += len(data)
+            dl_blob.update(data)
+            dl_file.write(data)
+
+        if not entry.size:
+            entry.size = dl_size
+
+        # Data fetched, link and rename temporary file.
+        entry.blob = str(dl_blob.hexdigest())
+        log.debug("fetch: ** Saved blob %s", entry.blob)
+
+        blob_path = entry.get_blob_path(self.__path)
+        blob_path.unlink(missing_ok=True)
+        blob_path.hardlink_to(dl_file.name)
+        dl_file.close()
+
+        entry.save(self.__path)
+
+        self.stats.bytes_remote += entry.size
+        self.stats.misses += 1
+        return False
+
+
+__all__ = [
+    "HTTPCache",
+]

--- a/wsa
+++ b/wsa
@@ -354,14 +354,24 @@ def cmd_check(args):
             reported_cves.update(wsa_data.keys())
     print("CVEs already in WSAs:", len(reported_cves), file=sys.stderr)
 
+    indexes = {"https://support.apple.com/en-us/HT201222"}
+    visited = set()
+    cves = {}
+
     def webkit_cve_entries(url):
+        entries = set()
+
         entry = None
         try:
             entry, _ = cache.get(url)
         except HTTPError as e:
             if e.code == 404:
-                print("Not found:", url, "-", e, file=sys.stderr)
-                return
+                print("\x1b[2KNot found:", url, "-", e, file=sys.stderr)
+                return entries
+
+        print("\x1b[2K*", url, "- visited:", len(visited),
+              "- pending:", len(indexes), "- CVEs:", len(cves), end="\r",
+                  file=sys.stderr)
 
         assert entry is not None
         tree = html.fromstring(cache.read_blob(entry))
@@ -410,56 +420,59 @@ def cmd_check(args):
                     continue
 
             if bugzilla and cve_id:
-                yield cve_id, bugzilla, author, impact, description
+                entries.add((cve_id, bugzilla, author, impact, description))
+        return entries
 
-    indexes = {"https://support.apple.com/en-us/HT201222"}
-    visited = set()
-    cves = {}
-
-    while indexes:
-        index_url = indexes.pop()
-        print("\x1b[2K*", index_url, "- visited:", len(visited),
-              "- pending:", len(indexes), "- CVEs:", len(cves), end="\r",
-              file=sys.stderr)
-        if index_url in visited:
-            continue
-
-        visited.add(index_url)
-
-        # TODO: Cache fetched data.
+    def fetch_index(url):
         entry = None
         try:
-            entry, _ = cache.get(index_url)
+            entry, _ = cache.get(url)
         except HTTPError as e:
             if e.code == 404:
-                print("Not found:", index_url, "-", e, file=sys.stderr)
-                continue
+                print("\x1b[2KNot found:", url, "-", e, file=sys.stderr)
+        return entry
 
-
-        assert entry is not None
-        tree = html.fromstring(cache.read_blob(entry))
-        tree.make_links_absolute(index_url)
-
+    def get_advisory_links(tree):
         for item in select_advisory_links(tree):
             url = item.get("href")
             if apple_support_url_re.match(url) and url not in visited:
-                visited.add(url)
-                for cve_id, bugzilla, author, impact, description in webkit_cve_entries(url):
-                    if cve_id in cves:
-                        continue
-                    cves[cve_id] = {"id": cve_id,
-                                    "bug": int(bugzilla),
-                                    "author": author,
-                                    "impact": impact,
-                                    "description": description,
-                                    "url": url}
+                yield url
+
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=10) as exec:
+        while indexes:
+            urls = {url for url in indexes if url not in visited}
+            indexes.clear()
+
+            for url, entry in zip(urls, exec.map(fetch_index, urls)):
                 print("\x1b[2K*", url, "- visited:", len(visited),
                       "- pending:", len(indexes), "- CVEs:", len(cves), end="\r",
                       file=sys.stderr)
-        for item in select_index_links(tree):
-            url = item.get("href")
-            if apple_support_url_re.match(url) and url not in visited:
-                indexes.add(url)
+                visited.add(url)
+                if entry is None:
+                    continue
+
+                tree = html.fromstring(cache.read_blob(entry))
+                tree.make_links_absolute(url)
+
+                advisory_urls = set(get_advisory_links(tree))
+                visited.update(advisory_urls)
+
+                for item in select_index_links(tree):
+                    url = item.get("href")
+                    if apple_support_url_re.match(url) and url not in visited:
+                        indexes.add(url)
+
+                for entries in exec.map(webkit_cve_entries, advisory_urls):
+                    for cve_id, bugzilla, author, impact, description in entries:
+                        if cve_id in cves:
+                            continue
+                        cves[cve_id] = {"id": cve_id,
+                                        "bug": int(bugzilla),
+                                        "author": author,
+                                        "impact": impact,
+                                        "description": description,
+                                        "url": url}
     print("\x1b[2KFetched CVEs:", len(cves), file=sys.stderr)
 
     known_cves = set(cves.keys())

--- a/wsa
+++ b/wsa
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 from argparse import ArgumentParser
+from dataclasses import asdict
 from pathlib import Path
 from ruamel.yaml import YAML
 from time import strftime
@@ -478,6 +479,12 @@ def cmd_check(args):
     known_cves = set(cves.keys())
     missing_cves = known_cves - reported_cves
     print("Missing CVEs:", len(missing_cves), file=sys.stderr)
+
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    if args.cache_stats:
+        yaml.dump(dict(cache_stats=asdict(cache.stats)), sys.stderr)
+
     if not missing_cves:
         return
 
@@ -491,8 +498,7 @@ def cmd_check(args):
                 item[key] = value
         cve_data[cve_id] = item
         cve_data.yaml_add_eol_comment(cves[cve_id]["url"], cve_id, column=0)
-    yaml = YAML()
-    yaml.indent(mapping=2, sequence=4, offset=2)
+
     yaml.dump(cve_data, sys.stdout)
 
 
@@ -515,6 +521,7 @@ fil_parser.add_argument("report_yml", type=Path, nargs="+", help="path to the WS
 
 chk_parser = subparsers.add_parser("check", description="Check for CVEs in Apple security advisories")
 chk_parser.add_argument("-c", "--cache", type=Path, default=None, help="path to directory used as HTTP cache")
+chk_parser.add_argument("--cache-stats", action="store_true", default=False, help="Print HTTP cache statistics")
 chk_parser.add_argument("report_yml", type=Path, nargs="*", help="path to WSA report YAML source")
 
 args = arg_parser.parse_args()

--- a/wsa
+++ b/wsa
@@ -4,7 +4,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from ruamel.yaml import YAML
 from time import strftime
-from urllib.parse import urlparse, urlunparse
 
 import re
 import sys
@@ -316,7 +315,7 @@ def cmd_fill(args):
 
 
 def cmd_check(args):
-    from urllib.request import urlopen
+    from httpcache import HTTPCache
     from urllib.error import HTTPError
     from lxml.cssselect import CSSSelector
     from lxml import html
@@ -334,10 +333,19 @@ def cmd_check(args):
     select_index_links = CSSSelector("ul > li > p > a")
     select_paragraphs = CSSSelector("p")
 
+    if not args.cache:
+        args.cache = Path(__file__).parent / "httpcache"
+
     if not args.report_yml:
         from itertools import chain
         cvedata_path = Path(__file__).parent / "cvedata"
         args.report_yml = chain(cvedata_path.glob("*.yml"), cvedata_path.glob("*.yaml"))
+
+    if args.cache.exists() and not args.cache.is_dir():
+        raise SystemExit(f"Path {args.cache!r} is not a directory")
+
+    args.cache.mkdir(parents=True, exist_ok=True)
+    cache = HTTPCache(args.cache)
 
     reported_cves = set()
     for wsa_yaml_path in args.report_yml:
@@ -347,13 +355,16 @@ def cmd_check(args):
     print("CVEs already in WSAs:", len(reported_cves), file=sys.stderr)
 
     def webkit_cve_entries(url):
+        entry = None
         try:
-            data = urlopen(url).read()
+            entry, _ = cache.get(url)
         except HTTPError as e:
             if e.code == 404:
                 print("Not found:", url, "-", e, file=sys.stderr)
                 return
-        tree = html.fromstring(data)
+
+        assert entry is not None
+        tree = html.fromstring(cache.read_blob(entry))
 
         for header in select_advisory_headers(tree):
             if header.text is None or not webkit_boundary_re.match(header.text):
@@ -416,14 +427,17 @@ def cmd_check(args):
         visited.add(index_url)
 
         # TODO: Cache fetched data.
+        entry = None
         try:
-            data = urlopen(index_url).read()
+            entry, _ = cache.get(index_url)
         except HTTPError as e:
             if e.code == 404:
                 print("Not found:", index_url, "-", e, file=sys.stderr)
                 continue
 
-        tree = html.fromstring(data)
+
+        assert entry is not None
+        tree = html.fromstring(cache.read_blob(entry))
         tree.make_links_absolute(index_url)
 
         for item in select_advisory_links(tree):
@@ -487,6 +501,7 @@ fil_parser.add_argument("-i", "--inplace", action="store_true", default=False, h
 fil_parser.add_argument("report_yml", type=Path, nargs="+", help="path to the WSA report YAML source")
 
 chk_parser = subparsers.add_parser("check", description="Check for CVEs in Apple security advisories")
+chk_parser.add_argument("-c", "--cache", type=Path, default=None, help="path to directory used as HTTP cache")
 chk_parser.add_argument("report_yml", type=Path, nargs="*", help="path to WSA report YAML source")
 
 args = arg_parser.parse_args()

--- a/wsa
+++ b/wsa
@@ -8,6 +8,7 @@ from time import strftime
 
 import re
 import sys
+import logging
 import textwrap
 
 class Formatter:
@@ -502,7 +503,13 @@ def cmd_check(args):
     yaml.dump(cve_data, sys.stdout)
 
 
+log_levels = {logging.getLevelName(level).lower(): level
+    for level in (logging.INFO, logging.DEBUG, logging.ERROR, logging.WARNING, logging.FATAL)}
+log_level_default_name = logging.getLevelName(logging.WARNING).lower()
+
 arg_parser = ArgumentParser()
+arg_parser.add_argument("--log", choices=log_levels.keys(), default=log_level_default_name,
+    help=f"set log level (default: {log_level_default_name})")
 subparsers = arg_parser.add_subparsers(dest="subcommand", required=True)
 
 gen_parser = subparsers.add_parser("generate", aliases=("gen",), description="Generate advisory text.")
@@ -525,7 +532,7 @@ chk_parser.add_argument("--cache-stats", action="store_true", default=False, hel
 chk_parser.add_argument("report_yml", type=Path, nargs="*", help="path to WSA report YAML source")
 
 args = arg_parser.parse_args()
-
+logging.basicConfig(level=log_levels[args.log])
 ({
     "generate": cmd_generate, "gen": cmd_generate,
     "fill": cmd_fill,


### PR DESCRIPTION
This series of patches first add an `httpcache` submodule, which cuts down typical run times from about 15 minutes down to ~6 minutes. Then, parallel fetch using 10 threads further reduces run time down to ~2 minutes, and finally adding support for the `Expires` HTTP header to avoid hitting the server for fresh-enough items shaves another minute.

TL;DR: This gets run times for the `wsa check` command from 15 minutes down to 1.

As a bonus, the last two patches add support for printing cache statistics with `wsa check --cache-stats`, and for configuring the log level with `wsa --log=info|debug|error|warning|critical`. 