### PR TITLE
Update 2025-04-08-webkitgtk-2.48.md

### DIFF
--- a/_posts/2025-04-08-webkitgtk-2.48.md
+++ b/_posts/2025-04-08-webkitgtk-2.48.md
@@ -28,7 +28,7 @@ There have been several improvements to handling elements that use `preserve-3d`
 
 ### Damage Tracking
 
-This release gained experimental support for collecting “damage” information, which tracks which parts of Web content produce visual changes in the displayed output. This information is then taken into account to reuse existing graphics buffers and repaint only those parts that need to be modified. This results better performance and less resource usage.
+This release gained experimental support for [collecting “damage” information](https://blogs.igalia.com/plampe/introduction-to-damage-propagation-in-wpe-and-gtk-webkit-ports/), which tracks which parts of Web content produce visual changes in the displayed output. This information is then taken into account to reuse existing graphics buffers and repaint only those parts that need to be modified. This results better performance and less resource usage.
 
 Note that this feature is disabled by default and may be previewed toggling the `PropagateDamagingInformation` feature flag.
 


### PR DESCRIPTION
This change adds a link to a blog post on damage propagation