### PR TITLE
Replace outdated documentation links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -127,10 +127,10 @@
                         <div class="header contribute"><span>Contribute</span></div>
                         <ul>
                             <li class="subheader">&#8227; <a href="https://bugs.webkit.org/enter_bug.cgi?assigned_to=webkit-unassigned%40lists.webkit.org&attachurl=&blocked=&bug_file_loc=http://&bug_severity=Normal&bug_status=NEW&comment=&component=WebKit%20Gtk&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text/plain&data=&dependson=&description=&flag_type-1=X&flag_type-3=X&flag_type-4=X&form_name=enter_bug&keywords=GTK&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Linux&priority=P3&product=WebKit&rep_platform=PC&short_desc=%5BGTK%5D%20">File a bug</a></li>
-                            <li class="subheader">&#8227; <a href="https://www.webkit.org/building/checkout.html">Get the code</a></li>
-                            <li class="subheader">&#8227; <a href="https://trac.webkit.org/wiki/BuildingGtk">How to build</a></li>
-                            <li class="subheader">&#8227; <a href="https://www.webkit.org/coding/contributing.html">How to submit code</a></li>
-                            <li class="subheader">&#8227; <a href="https://trac.webkit.org/wiki/WebKitGTK/StableRelease">Stable branch</a></li>
+                            <li class="subheader">&#8227; <a href="https://docs.webkit.org/#downloading-the-source-code">Get the code</a></li>
+                            <li class="subheader">&#8227; <a href="https://docs.webkit.org/Build%20%26%20Debug/BuildOptions.html#building-the-gtk-port">How to build</a></li>
+                            <li class="subheader">&#8227; <a href="https://docs.webkit.org/Getting%20Started/ContributingCode.html">How to submit code</a></li>
+                            <li class="subheader">&#8227; <a href="https://docs.webkit.org/Ports/WebKitGTK%20and%20WPE%20WebKit/TipsForMaintainers.html#stable-branches">Stable branch</a></li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
Change the links from the sidebar pointing to `webkit.org` or the old Trac wiki to current, more up-to-date content hosted at `docs.webkit.org`.